### PR TITLE
Change order of the WhoAreWe block towards TOP

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,10 @@
 <section id="whoarewe">
 	<p class="title-for-mob">Qui sommes nous</p>
 
+	<div class="col-md-6 bg-who">
+	<h1>Qui sommes nous</h1>
+	</div>
+	
 	<div class="col-md-6">
 		<div class="col-md-6">
 			<img src="DATACTIVIST_fichiers/samuel.jpg" alt="samuel goeta">
@@ -149,9 +153,7 @@ visant à combattre les fake news.
 			<p><a href="mailto:cecile@datactivi.st">cecile@datactivi.st</a></p>
 		</div>
 	</div>
-	<div class="col-md-6 bg-who">
-		<h1>Qui sommes nous</h1>
-	</div>
+
 	<div class="clearfix"></div>
 </section>
 


### PR DESCRIPTION
Remonte le bloc de titre "Who are We" au dessus des bios. (Current: bloc titre en-dessous des bios)